### PR TITLE
Non-malicious symbols must be reverted to the original text.

### DIFF
--- a/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
+++ b/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
@@ -82,6 +82,10 @@ public class XssSanitizerUtil {
 				for (Pattern xssInputPattern : XSS_INPUT_PATTERNS) {
 					value = xssInputPattern.matcher(value).replaceAll("");
 				}
+				
+				// If the encoded incoming value is not malicious, then reverting it to the original text
+				// this is required for text containing &PI or &XI which is getting evaluated to the respective symbol.
+				
 			}
 
 		} catch (Exception ex) {


### PR DESCRIPTION
As a part of sanitizing the incoming request parameters the strings are converted to the respective symbol. If the symbol is non-malicious then it must be reverted to the original text. This is happening when text is having '&' followed by characters which may get evaluated to symbols. for e.g. &Mu is evaluated to the Greek symbol µ.