### PR TITLE
Update regex to handle trailing tags with backslash characters and avoid undesirable 'form' matches

### DIFF
--- a/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
+++ b/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
@@ -57,7 +57,7 @@ public class XssSanitizerUtil {
 			XSS_INPUT_PATTERNS.add(Pattern.compile("onfocus(.*?)=", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
 
 			// Avoid any form injection with <...form ...> ... </form ...> tag
-			XSS_INPUT_PATTERNS.add(Pattern.compile("<(.*?)form(.*?)>(.*?)</(.*?)form(.*?)>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<([^<>]*)form([^<>]*)>(.*?)</([^<>]*)form([^<>]*)>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
 	}
 
 	/**

--- a/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
+++ b/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
@@ -57,7 +57,7 @@ public class XssSanitizerUtil {
 			XSS_INPUT_PATTERNS.add(Pattern.compile("onfocus(.*?)=", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
 
 			// Avoid any form injection with <...form ...> ... </form ...> tag
-			XSS_INPUT_PATTERNS.add(Pattern.compile("<([^<>]*)form([^<>]*)>(.*?)</([^<>]*)form([^<>]*)>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<([^<>]*?)form([^<>]*?)>(.*?)</([^<>]*?)form([^<>]*?)>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
 	}
 
 	/**

--- a/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
+++ b/src/java/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtil.java
@@ -14,13 +14,13 @@ public class XssSanitizerUtil {
 
 	static {
 			// Avoid anything between script tags
-			XSS_INPUT_PATTERNS.add(Pattern.compile("<script>(.*?)</script>", Pattern.CASE_INSENSITIVE));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<script>(.*?)<[\\\\]*?/script>", Pattern.CASE_INSENSITIVE));
 
 			// avoid iframes
-			XSS_INPUT_PATTERNS.add(Pattern.compile("<iframe(.*?)>(.*?)</iframe>", Pattern.CASE_INSENSITIVE));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<iframe(.*?)>(.*?)<[\\\\]*?/iframe>", Pattern.CASE_INSENSITIVE));
 
 			// avoid inputs
-			XSS_INPUT_PATTERNS.add(Pattern.compile("<input(.*?)>(.*?)</input>", Pattern.CASE_INSENSITIVE));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<input(.*?)>(.*?)<[\\\\]*?/input>", Pattern.CASE_INSENSITIVE));
 
 			// Avoid anything in a src='...' type of expression
 			XSS_INPUT_PATTERNS.add(Pattern.compile("src[\r\n]*=[\r\n]*\\\'(.*?)\\\'", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
@@ -30,7 +30,7 @@ public class XssSanitizerUtil {
 			XSS_INPUT_PATTERNS.add(Pattern.compile("src[\r\n]*=[\r\n]*([^>]+)", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));
 
 			// Remove any lonesome </script> tag
-			XSS_INPUT_PATTERNS.add(Pattern.compile("</script>", Pattern.CASE_INSENSITIVE));
+			XSS_INPUT_PATTERNS.add(Pattern.compile("<[\\\\]*?/script>", Pattern.CASE_INSENSITIVE));
 
 			// Remove any lonesome <script ...> tag
 			XSS_INPUT_PATTERNS.add(Pattern.compile("<script(.*?)>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL));

--- a/test/unit/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtilTest.java
+++ b/test/unit/org/tonyzampogna/xss/sanitizer/util/XssSanitizerUtilTest.java
@@ -85,8 +85,40 @@ public class XssSanitizerUtilTest {
     }
 
     @Test
-    public void shouldStripOutContentOfIframeTags() {
+    public void shouldStripOutContentOfFormTags() {
         final String output = XssSanitizerUtil.stripXSS("<form action=''><input id='formInjection'></form>");
         assertThat(output, is(""));
+    }
+
+    @Test
+    public void shouldStripOutContentOfScriptTagsWithBackslash() {
+        final String output = XssSanitizerUtil.stripXSS("valid-content<script>xss-content<\\/script> more-valid-content");
+        assertThat(output, is("valid-content more-valid-content"));
+    }
+
+    @Test
+    public void shouldStripOutContentOfIframeTagsWithMultipleBackslash() {
+        final String output = XssSanitizerUtil.stripXSS("valid-content<iframe>xss-content<\\\\/iframe> more-valid-content");
+        assertThat(output, is("valid-content more-valid-content"));
+    }
+
+    @Test
+    public void shouldStripOutContentOfInputTagsWithBackslash() {
+        final String output = XssSanitizerUtil.stripXSS("valid-content<input>xss-content<\\/input> more-valid-content");
+        assertThat(output, is("valid-content more-valid-content"));
+    }
+
+    @Test
+    public void shouldStripOutTrailingScriptTagWithBackslash() {
+        final String output = XssSanitizerUtil.stripXSS("<\\/script>valid-content");
+        assertThat(output, is("valid-content"));
+    }
+
+    @Test
+    public void shouldNotStripTagAttributeContainingForm() {
+        final String input = "<self-closing-tag expression=\"payload.Data.Initiation.RemittanceInformation\"  gen=\"jag\"/>" +
+                "<self-closing-tag expression=\"payload.Data.Initiation.RemittanceInformation.Unstructured\"  gen=\"jag\"/>";
+        final String output = XssSanitizerUtil.stripXSS(input);
+        assertThat(output, is(input));
     }
 }


### PR DESCRIPTION
Existing regex causes problems with sending XML containing `form` within the tag. For example:

```
<tag expression="payload.Data.Initiation.RemittanceInformation"  gen="jag"/>
```